### PR TITLE
Add `Enumerable.Zip`

### DIFF
--- a/addons/linq/iterator.gd
+++ b/addons/linq/iterator.gd
@@ -46,4 +46,7 @@ func select_many(collection_selector: Callable, result_selector: Callable = Call
 func where(predicate: Callable) -> WhereIterator:
 	return WhereIterator.new(self, predicate);
 
+func zip(other: Variant) -> ZipIterator:
+	return ZipIterator.new(self, Iterator.from(other));
+
 #endregion Extension methods

--- a/addons/linq/operations/zip_iterator.gd
+++ b/addons/linq/operations/zip_iterator.gd
@@ -1,0 +1,24 @@
+class_name ZipIterator extends ChainedIterator
+
+var _other: Iterator;
+
+func _init(source: Iterator, other: Iterator) -> void:
+	super(source);
+	_other = other;
+
+func _iter_init(iter: Array) -> bool:
+	var state := State.new();
+	iter[0] = state;
+	return _source._iter_init(state.source_state) and _other._iter_init(state.other_state);
+	
+func _iter_next(iter: Array) -> bool:
+	var state := iter[0] as State;
+	return _source._iter_next(state.source_state) and _other._iter_next(state.other_state);
+	
+func _iter_get(iter: Variant) -> Variant:
+	var state := iter[0] as State;
+	return [_source._iter_get(state.source_state), _other._iter_get(state.other_state)];
+
+class State extends RefCounted:
+	var source_state := [null];
+	var other_state := [null];

--- a/addons/linq/operations/zip_iterator.gd.uid
+++ b/addons/linq/operations/zip_iterator.gd.uid
@@ -1,0 +1,1 @@
+uid://8w5mdqbddmg0


### PR DESCRIPTION
This pull-request adds support for the `zip(…)` operator. It accepts another object which can be turned into an `Iterator` by  calling `Iterator.from(…)`. Each element in the result source will be an array with two element: `[source[i], other[i]]`.

It generates elements as long as both sources generate elements.

closes #7