### PR TITLE
Add `Enumerable.All` and `Enumerable.Empty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,33 @@ While Godot does allow [implementing custom iterators][custom_iterator], it does
 An implementation has been provided for:
 
 - `Array` or any of the `Packed…Array` types
-- ~~`Dictionary` each entry is represented as an array with 2 elements: `[key, value]`~~
+- `Dictionary` each entry is represented as an array with 2 elements: `[key, value]`
 - [`Iterator`]
 
 </dd>
 </dl>
 
 ## Instance methods
+
+### `all(…)`
+```gdscript
+func all(predicate: Callable) -> bool
+```
+
+Returns `true` if `predicate` returns `true` for each element in the sequence, or if the sequence is empty.
+
+Stops as soon as any invocation returns `false`.
+
+### Parameters
+
+<dl>
+<dt><dfn>predicate</dfn></dt>
+<dd>
+```gdscript
+func predicate(element: Variant) -> bool
+```
+</dd>
+</dl>
 
 ### `select(…)`
 
@@ -121,7 +141,8 @@ func result_selector(source: Variant, element: Variant) -> Variant
 ```
 Callback which allows transforming the `element`. This is similar to chaining [`select`], but in this case the `source` is also provided, which allows for setting up references. 
 
-> [!NOTE] The first argument is the same element as provided to `collection_selector`. 
+> [!NOTE] 
+> The first argument is the same element as provided to `collection_selector`. 
 
 The default implementation (if this callback is omited) returns `element`.
 

--- a/addons/linq/iterator.gd
+++ b/addons/linq/iterator.gd
@@ -20,9 +20,14 @@ static func from(value: Variant) -> Iterator:
 		TYPE_DICTIONARY:
 			return DictionaryIterator.new(value);
 		var type:
-			# TODO: Add support for more types which can be iterated.
 			assert(false, "[Iterator.from()] does not support type [{type}]".format({ "type": type_string(type) }));
-	return null;
+	return empty();
+
+## Returns an [Iterator] that does [b]not[/b] yield any elements.
+##
+## Use in place of [code]null[/code]
+static func empty() -> Iterator:
+	return Iterator.new();
 
 #region Implements interfaces
 
@@ -39,6 +44,19 @@ func _iter_get(iter: Variant) -> Variant:
 
 #region Extension methods
 
+## Returns [code]true[/code] if [param predicate] returns [code]true[/code] for each element in the sequence.
+##
+## Stops as soon as any invocation returns [code]false[/code].[br][br]
+##
+## [param predicate] has the following signature.
+## [codeblock]
+## func predicate(value: Variant) -> bool
+## [/codeblock]
+func all(predicate: Callable) -> bool:
+	for value in self:
+		if not predicate.call(value):
+			return false;
+	return true;
 ## Counts elements for which [param predicate] returns [code]true[/code]. If no
 ## [param predicate] has been provided, all elements are counted.[br][br]
 ##

--- a/tests/unit/test_iterator.gd
+++ b/tests/unit/test_iterator.gd
@@ -1,5 +1,36 @@
 extends GutTest
 
+class TestAll extends GutTest:
+	
+	const cases := [
+		[[], true, { "next": 0, "get": 0 }],
+		[[false], false, { "next": 0, "get": 1 }],
+		[[true], true, { "next": 1, "get": 1 }],
+		[[false, false], false, { "next": 0, "get": 1 }],
+		[[false, true], false, { "next": 0, "get": 1 }],
+		[[true, false], false, { "next": 1, "get": 2 }],
+		[[true, true], true, { "next": 2, "get": 2 }],
+	]
+	
+	func test_all(params = use_parameters(cases)):
+		var sequence := params[0] as Array;
+		var expected_return_value := params[1] as bool;
+		var expected_number_of_evaluations := params[2] as Dictionary;
+		
+		var MockedIterator = double(Iterator);
+		var mock = MockedIterator.new();
+		stub(mock, &"_iter_init").to_call(func(iter): iter[0] = 0; return iter[0] < len(sequence));
+		stub(mock, &"_iter_next").to_call(func(iter): iter[0] += 1; return iter[0] < len(sequence));
+		stub(mock, &"_iter_get").to_call(func(iter): return sequence[iter]);
+		var subject := ChainedIterator.new(mock);
+		
+		var result := subject.all(func(e): return e);
+		
+		assert_eq(result, expected_return_value);
+		assert_call_count(mock, &"_iter_init", 1);
+		assert_call_count(mock, &"_iter_next", expected_number_of_evaluations.get("next"));
+		assert_call_count(mock, &"_iter_get", expected_number_of_evaluations.get("get"));
+
 class TestCount extends GutTest:
 	
 	const without_callback_cases := [


### PR DESCRIPTION
closes #18 