### PR TITLE
Ground work for various `…OrDefault()` method

### DIFF
--- a/addons/linq/iterator.gd
+++ b/addons/linq/iterator.gd
@@ -114,3 +114,11 @@ func zip(other: Variant) -> ZipIterator:
 	return ZipIterator.new(self, Iterator.from(other));
 
 #endregion Extension methods
+
+## Virtual method for generating a default value based on the type of data this 
+## iterator yields.
+##
+## Used internally by methods like [method default_if_empty], [method first_or_default], 
+## [method single_or_default].
+func _default() -> Variant:
+	return null;

--- a/addons/linq/operations/select_iterator.gd
+++ b/addons/linq/operations/select_iterator.gd
@@ -33,6 +33,10 @@ func _iter_get(iter: Variant) -> Variant:
 	var state := iter as State;
 	var current := super(state.source_iterator_state[0]);
 	return _selector.call(current, state.index);
+	
+func _default() -> Variant:
+	push_warning("[SelectIterator] always returns [null] as default value because [selector]'s return type cannot be determined.");
+	return null;
 
 class State extends RefCounted:
 	var source_iterator_state := [null];

--- a/addons/linq/operations/select_many_iterator.gd
+++ b/addons/linq/operations/select_many_iterator.gd
@@ -83,6 +83,10 @@ func _iter_get(iter: Variant) -> Variant:
 	var current := state.sub_collection_iterator._iter_get(state.sub_collection_iterator_state[0]);
 	return _result_selector.call(state.source_element, current);
 
+func _default() -> Variant:
+	push_warning("[SelectManyIterator] always returns [null] because [selector]s'return type cannot be determined.");
+	return null;
+
 static func _default_result_selector(source: Variant, element: Variant) -> Variant:
 	return element;
 

--- a/addons/linq/operations/zip_iterator.gd
+++ b/addons/linq/operations/zip_iterator.gd
@@ -19,6 +19,9 @@ func _iter_get(iter: Variant) -> Variant:
 	var state := iter[0] as State;
 	return [_source._iter_get(state.source_state), _other._iter_get(state.other_state)];
 
+func _default() -> Variant:
+	return [_source._default(), _other._default()];
+
 class State extends RefCounted:
 	var source_state := [null];
 	var other_state := [null];

--- a/addons/linq/sources/array_iterator.gd
+++ b/addons/linq/sources/array_iterator.gd
@@ -1,8 +1,8 @@
 class_name ArrayIterator extends Iterator
 
-var _source: Array;
+var _source: Variant;
 
-func _init(source: Array) -> void:
+func _init(source: Variant) -> void:
 	_source = source;
 
 func _iter_init(iter: Array) -> bool:
@@ -15,3 +15,21 @@ func _iter_next(iter: Array) -> bool:
 
 func _iter_get(iter: Variant) -> Variant:
 	return _source[iter];
+
+func _default() -> Variant:
+	match typeof(_source):
+		TYPE_ARRAY:
+			return type_convert(null, (_source as Array).get_typed_builtin());
+		TYPE_PACKED_BYTE_ARRAY: return type_convert(null, TYPE_INT); # GdScript does not have a [byte] type.
+		TYPE_PACKED_COLOR_ARRAY: return type_convert(null, TYPE_COLOR);
+		TYPE_PACKED_FLOAT32_ARRAY: return type_convert(null, TYPE_FLOAT);
+		TYPE_PACKED_FLOAT64_ARRAY: return type_convert(null, TYPE_FLOAT);
+		TYPE_PACKED_INT32_ARRAY: return type_convert(null, TYPE_INT);
+		TYPE_PACKED_INT64_ARRAY: return type_convert(null, TYPE_INT);
+		TYPE_PACKED_VECTOR2_ARRAY: return type_convert(null, TYPE_VECTOR2);
+		TYPE_PACKED_VECTOR3_ARRAY: return type_convert(null, TYPE_VECTOR3);
+		TYPE_PACKED_VECTOR4_ARRAY: return type_convert(null, TYPE_VECTOR4);
+		TYPE_PACKED_STRING_ARRAY: return type_convert(null, TYPE_STRING);
+		
+		var type: push_error("[ArrayIterator] could not determine intended default for {type}".format({ "type": type_string(type) }));
+	return null;

--- a/addons/linq/sources/dictionary_iterator.gd
+++ b/addons/linq/sources/dictionary_iterator.gd
@@ -21,6 +21,14 @@ func _iter_get(iter: Variant) -> Variant:
 	var key := state.key_iterator._iter_get(state.key_iterator_state[0]);
 	return [key, _source.get(key)];
 
+## Returns an [Array] with two elements with the default values of respectively
+## the key's type and the value's type.
+func _default() -> Variant:
+	return [
+		type_convert(null, _source.get_typed_key_builtin()),
+		type_convert(null, _source.get_typed_value_builtin())
+	];
+
 class State extends RefCounted:
 	var key_iterator: Iterator;
 	var key_iterator_state := [null];


### PR DESCRIPTION
Prerequisite to various `…OrDefault()` methods. Tries to replicate generics somewhat.
- #27 
- #41 
- #45 
- #53
- #68 