### PR TITLE
Replaced some default parameters with more explicit `undefined` value.

### DIFF
--- a/addons/linq/iterator.gd
+++ b/addons/linq/iterator.gd
@@ -1,5 +1,10 @@
 class_name Iterator extends RefCounted
 
+## Used as default value in methods with overloads where one argument could be
+## anything. It is treated as not providing a value.
+static func UNDEFINED() -> void:
+	push_error("[Iterator.UNDEFINED()] should not be invoked!");
+
 static func from(value: Variant) -> Iterator:
 	match typeof(value):
 		TYPE_OBJECT:
@@ -79,9 +84,9 @@ func all(predicate: Callable) -> bool:
 ##
 ## If [param predicate] is not provided, it assumes all elements would return
 ## [code]true[/code]. In other words: the sequence contains 1 or more elements.
-func any(predicate: Callable = Callable()) -> bool:
+func any(predicate: Callable = UNDEFINED) -> bool:
 	for element in self:
-		if not predicate.is_valid() or predicate.call(element):
+		if is_same(predicate, UNDEFINED) or predicate.call(element):
 			return true;
 		
 	return false;
@@ -93,10 +98,10 @@ func any(predicate: Callable = Callable()) -> bool:
 ## [codeblock]
 ## func predicate(value: Variant) -> bool
 ## [/codeblock]
-func count(predicate: Callable = Callable()) -> int:
+func count(predicate: Callable = UNDEFINED) -> int:
 	var count := 0;
 	for element in self:
-		if not predicate.is_valid() or predicate.call(element):
+		if is_same(predicate, UNDEFINED) or predicate.call(element):
 			count += 1;
 			
 	return count;
@@ -104,7 +109,7 @@ func count(predicate: Callable = Callable()) -> int:
 func select(selector: Callable) -> SelectIterator:
 	return SelectIterator.new(self, selector);
 
-func select_many(collection_selector: Callable, result_selector: Callable = Callable()) -> SelectManyIterator:
+func select_many(collection_selector: Callable, result_selector: Callable = UNDEFINED) -> SelectManyIterator:
 	return SelectManyIterator.new(self, collection_selector, result_selector);
 
 func where(predicate: Callable) -> WhereIterator:

--- a/addons/linq/operations/select_many_iterator.gd
+++ b/addons/linq/operations/select_many_iterator.gd
@@ -3,7 +3,7 @@ class_name SelectManyIterator extends ChainedIterator
 var _collection_selector: Callable;
 var _result_selector: Callable;
 
-func _init(source: Iterator, collection_selector: Callable, result_selector: Callable = Callable()) -> void:
+func _init(source: Iterator, collection_selector: Callable, result_selector: Callable = UNDEFINED) -> void:
 	super(source);
 	_collection_selector = _resolve_collection_selector_overload(collection_selector);
 	_result_selector = _resolve_result_selector_overload(result_selector);
@@ -25,8 +25,12 @@ func _resolve_collection_selector_overload(collection_selector: Callable) -> Cal
 	return Callable();
 
 func _resolve_result_selector_overload(result_selector: Callable) -> Callable:
-	if not result_selector.is_valid():
+	if is_same(result_selector, UNDEFINED):
 		return _default_result_selector;
+		
+	if not result_selector.is_valid():
+		push_error("[SelectManyIterator] requires either a valid [param result_selector] or its default value.");
+		return result_selector;
 		
 	match result_selector.get_argument_count():
 		# func result_selector() -> Variant


### PR DESCRIPTION
Some methods provide overloads, implemented via default values. The provided value is used to determine which overload is intended. However if an overload allows any `Variant`, it can become ambiguous whether the default value is intended, or it happens to be the same value as the default.